### PR TITLE
Use Shadow DOM mode 'open'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ export function register ( tagName, Component, props = [] ) {
 		constructor () {
 			super();
 
-			this.target = this.attachShadow({ mode: 'closed' });
+			this.target = this;
 			this.data = {};
 		}
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ export function register ( tagName, Component, props = [] ) {
 		constructor () {
 			super();
 
-			this.target = this;
+			this.target = this.attachShadow({ mode: 'open' });
 			this.data = {};
 		}
 


### PR DESCRIPTION
-  Changes use of Shadow DOM to open, closed was causing Svelte component’s
embedded styles wrapped by the lib to have no effect